### PR TITLE
Use docker image in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,15 @@ pytest
 
 ## Deployment
 
+First you'll need to build a Docker image and publish it DockerHub:
+
+```
+DOCKER_DEFAULT_PLATFORM="linux/amd64" docker build . -t suldlss/rialto-airflow:latest
+docker push suldlss/rialto-airflow
+```
+
 Deployment to https://sul-rialto-airflow-dev.stanford.edu/ is handled like other SDR services using Capistrano. You'll need to have Ruby installed and then:
 
 ```
-gem install bundler
-bundle install
 bundle exec cap dev deploy
 ```

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -50,7 +50,7 @@ x-airflow-common:
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
    #image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.2}
-  build: .
+  image: ${AIRFLOW_IMAGE_NAME:-suldlss/rialto-airflow:latest}
   environment:
     &airflow-common-env
     AIRFLOW_UID: 503


### PR DESCRIPTION
I noticed that the latest Docker image wasn't being built on deploy because dlss-capistrano-docker wants to deploy an image rather and doesn't rebuild the container.

So I updated the docker compose production configuration to use a published image suldss/rialto-airflow (like dlme-airflow), and also added instructions for building and publishing the image to the README.
