### PR TITLE
Normalize DOIs in doi_sunet and merge_pubs tasks

### DIFF
--- a/rialto_airflow/harvest/doi_sunet.py
+++ b/rialto_airflow/harvest/doi_sunet.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 # TODO: use polars instead?
 import pandas as pd
 
+from rialto_airflow.utils import normalize_doi
+
 
 def create_doi_sunet_pickle(
     dimensions: str, openalex: str, sul_pub_csv: str, authors_csv: str, output_path
@@ -42,6 +44,7 @@ def doi_sunetids(pickle_file: str, orcid_sunet: dict) -> dict:
 
     mapping = {}
     for doi, orcids in doi_orcids.items():
+        doi = normalize_doi(doi)
         mapping[doi] = [orcid_sunet[orcid] for orcid in orcids]
 
     return mapping
@@ -52,6 +55,7 @@ def sulpub_doi_sunetids(sul_pub_csv, cap_profile_sunet):
     # extracted from the authorship column
     df = pd.read_csv(sul_pub_csv, usecols=["doi", "authorship"])
     df = df[df["doi"].notna()]
+    df["doi"] = df["doi"].apply(lambda doi: normalize_doi(doi))
 
     def extract_cap_ids(authors):
         return [a["cap_profile_id"] for a in eval(authors) if a["status"] == "approved"]

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 from pathlib import Path
+import re
 
 
 def create_snapshot_dir(data_dir):
@@ -54,3 +55,11 @@ def invert_dict(dict):
         inverted_dict[i] = [k for k, v in dict.items() if i in v]
 
     return inverted_dict
+
+
+def normalize_doi(doi):
+    doi = doi.strip().lower()
+    doi = doi.replace("https://doi.org/", "").replace("https://dx.doi.org/", "")
+    doi = re.sub("^doi: ", "", doi)
+
+    return doi

--- a/test/harvest/test_doi_sunet.py
+++ b/test/harvest/test_doi_sunet.py
@@ -57,8 +57,11 @@ def sul_pub_csv(tmp_path):
     with open(fixture_file, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["authorship", "title", "doi"])
-        writer.writerow([authorship("cap-01"), "A Publication", "10.0000/aaaa"])
-        writer.writerow([authorship("cap-02"), "A Research Article", "10.0000/1234"])
+        # include DOIs that will be normalized
+        writer.writerow([authorship("cap-01"), "A Publication", "10.0000/aAaA"])
+        writer.writerow(
+            [authorship("cap-02"), "A Research Article", "https://doi.org/10.0000/1234"]
+        )
     return fixture_file
 
 

--- a/test/harvest/test_merge_pubs.py
+++ b/test/harvest/test_merge_pubs.py
@@ -34,7 +34,7 @@ def dimensions_pubs_csv(tmp_path):
                 "1",
                 "[]",
                 "ARTICLE",
-                "10.0000/aaaa",
+                "10.0000/aAaA",
                 "[]",
                 "[]",
                 "True",
@@ -130,7 +130,7 @@ def sul_pubs_csv(tmp_path):
                 "[]",
                 "A Published Research Article",
                 "2024",
-                "https://doi.org/10.0000/dddd",
+                "doi: 10.0000/dDdD",
             ]
         )
     return fixture_file

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -57,3 +57,13 @@ def test_invert_dict():
         "pub_id7",
     ]
     assert inverted_dict["pub_id2"] == ["person_id1", "person_id2"]
+
+
+def test_normalize_doi():
+    assert utils.normalize_doi("https://doi.org/10.1234/5678") == "10.1234/5678"
+    assert utils.normalize_doi("https://dx.doi.org/10.1234/5678") == "10.1234/5678"
+    assert (
+        utils.normalize_doi("10.1103/PhysRevLett.96.07390")
+        == "10.1103/physrevlett.96.07390"
+    )
+    assert utils.normalize_doi(" doi: 10.1234/5678 ") == "10.1234/5678"


### PR DESCRIPTION
Resolves #72 to make DOIs consistent across sources for accurate doi->sunet mapping and publication merging. 

There are still some sul_pub DOIs that will be malformatted for matching because of the variability of that data source. Just hoping that they do not cause any problems in lookups downstream. Will test by running the branch on prod with the full data. 

Ran DAG locally with a small dev limit and that succeeded.