### PR TITLE
Handle single DOI invalid in OpenAlex

### DIFF
--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -100,7 +100,8 @@ def publications_from_dois(dois: list):
                     pubs = Works().filter(doi=doi).get()
                     if len(pubs) > 1:
                         logging.warn(f"Found multiple publications for DOI {doi}")
-                    yield normalize_publication(pubs[0])
+                    if len(pubs) > 0:
+                        yield normalize_publication(pubs[0])
                 except api.QueryError as e:
                     logging.error(f"OpenAlex QueryError for {doi}: {e}")
                     continue

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -65,6 +65,17 @@ def test_publications_from_invalid_dois(caplog):
     ), "logs error message"
 
 
+def test_publications_from_invalid_with_comma(caplog):
+    # OpenAlex will interpret a DOI string with a comma as two DOIs but
+    # Does not return a result for the first half even if valid. Will return an empty list
+    invalid_doi = ["10.1002/cncr.33546,-(wileyonlinelibrary.com)"]
+    assert len(list(openalex.publications_from_dois(invalid_doi))) == 0
+    assert (
+        "OpenAlex QueryError for 10.1002/cncr.33546,-(wileyonlinelibrary.com): Invalid query parameter"
+        in caplog.text
+    ), "logs error message"
+
+
 def test_publications_csv(tmp_path):
     pubs_csv = tmp_path / "openalex-pubs.csv"
     openalex.publications_csv(


### PR DESCRIPTION
OpenAlex handles DOIs with commas in a way that wasn't expected and may return an empty list before erroring on the second half. 