### PR TITLE
Limit the response size for ORCID lookup

### DIFF
--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -58,7 +58,9 @@ def dois_from_orcid(orcid: str, limit=None):
 
     # get all the works for the openalex author id
     work_count = 0
-    for page in Works().filter(author={"id": author_id}).paginate(per_page=200):
+    for page in (
+        Works().filter(author={"id": author_id}).select(["doi"]).paginate(per_page=200)
+    ):
         for pub in page:
             if pub.get("doi"):
                 work_count += 1

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -98,3 +98,9 @@ def test_pyalex_urlencoding():
         )
         == 2
     ), "we handle url URL encoding DOIs until pyalex does"
+
+
+def test_pyalex_varnish_bug():
+    # it seems like this author has a few records that are so big they blow out
+    # OpenAlex's Varnish index. See https://groups.google.com/u/1/g/openalex-community/c/hl09WRF3Naw
+    assert len(list(openalex.dois_from_orcid("0000-0003-3859-2905"))) > 270


### PR DESCRIPTION
We are encountering situations when looking up works for an ORCID are encountering an OpenAlex API Varnish error when the response is too big. To avoid this we can only request the DOI instead of the full record, which limits the size of the response, while continuing to page with `per_page=200`.

Fixes #79
