### PR TITLE
Added csv_to_parquet()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "dimcli",
     "polars>=1.2",
     "pyalex",
-    "more-itertools"
+    "more-itertools",
+    "pyarrow"
 ]
 
 [tool.pytest.ini_options]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,6 +2,7 @@ import csv
 from pathlib import Path
 
 import pytest
+import polars
 
 from rialto_airflow import utils
 
@@ -67,3 +68,14 @@ def test_normalize_doi():
         == "10.1103/physrevlett.96.07390"
     )
     assert utils.normalize_doi(" doi: 10.1234/5678 ") == "10.1234/5678"
+
+
+def test_csv_to_parquet(tmp_path):
+    csv_file = Path("test/data/authors.csv")
+    parquet_file = tmp_path / "authors.parquet"
+    utils.csv_to_parquet(csv_file, parquet_file)
+
+    assert parquet_file.is_file()
+    df = polars.read_parquet(parquet_file)
+
+    assert df.shape == (10, 2)


### PR DESCRIPTION
The `utils.csv_to_parquet()` function will efficiently create a Parquet file for the given CSV. It currently assumes that the Parquet file schema where all the columns are strings. But if it's useful we could adjust this and allow a schema to be passed in?

The reason why we don't simply use Polars for this is that it seems to use large amounts of memory given the CSVs that we are collecting. See https://github.com/pola-rs/polars/issues/13458#issuecomment-2238905606 for context.
