### PR TITLE
Remove authors from output Parquet

### DIFF
--- a/rialto_airflow/harvest/merge_pubs.py
+++ b/rialto_airflow/harvest/merge_pubs.py
@@ -54,7 +54,6 @@ def dimensions_pubs_df(dimensions_pubs):
     df = df.select(
         pl.col("doi").map_elements(normalize_doi, return_dtype=pl.String),
         pl.col(
-            "authors",
             "document_type",
             "funders",
             "funding_section",
@@ -80,9 +79,7 @@ def openalex_pubs_df(openalex_pubs):
     )
     df = df.select(
         pl.col("doi").map_elements(normalize_doi, return_dtype=pl.String),
-        pl.col(
-            "apc_paid", "authorships", "grants", "publication_year", "title", "type"
-        ),
+        pl.col("apc_paid", "grants", "publication_year", "title", "type"),
     )
     df = df.rename(lambda column_name: "openalex_" + column_name)
     return df

--- a/test/harvest/test_merge_pubs.py
+++ b/test/harvest/test_merge_pubs.py
@@ -186,7 +186,7 @@ def test_merge(tmp_path, sul_pubs_csv, openalex_pubs_csv, dimensions_pubs_csv):
     assert output.is_file(), "output file has been created"
     df = pl.read_parquet(output)
     assert df.shape[0] == 5
-    assert df.shape[1] == 25
+    assert df.shape[1] == 23
     assert set(df["doi"].to_list()) == set(
         ["10.0000/aaaa", "10.0000/1234", "10.0000/cccc", "10.0000/dddd", "10.0000/eeee"]
     )


### PR DESCRIPTION
It appears to help conserve RAM (13GB instead of 18GB) to not serialize the authorships and authors columns to the Parquet file. Since we aren't using them in any of our reporting this will help us when generating the full dataset in production.
