### PR TITLE
Upgrade Airflow and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.9.2-python3.12
+FROM apache/airflow:2.9.3-python3.12
 
 USER root
 RUN apt-get update && apt-get install -y gcc git

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -24,7 +24,7 @@
 # The following variables are supported:
 #
 # AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.9.2
+#                                Default: apache/airflow:2.9.3
 # AIRFLOW_UID                  - User ID in Airflow containers
 #                                Default: 50000
 # AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
@@ -49,7 +49,7 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-   #image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.2}
+   #image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.3}
   image: ${AIRFLOW_IMAGE_NAME:-suldlss/rialto-airflow:latest}
   environment:
     &airflow-common-env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@
 # The following variables are supported:
 #
 # AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.9.2
+#                                Default: apache/airflow:2.9.3
 # AIRFLOW_UID                  - User ID in Airflow containers
 #                                Default: 50000
 # AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
@@ -49,7 +49,7 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-   #image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.2}
+  # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.3}
   build: .
   environment:
     &airflow-common-env

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest
 python-dotenv
 ruff
-apache-airflow==2.9.2
+apache-airflow==2.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ asttokens==2.4.1
     # via stack-data
 babel==2.15.0
     # via sphinx
-certifi==2024.6.2
+certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -16,7 +16,7 @@ commonmark==0.9.1
     # via recommonmark
 decorator==5.1.1
     # via ipython
-dimcli==1.2
+dimcli==1.3
     # via rialto-airflow (pyproject.toml)
 docutils==0.21.2
     # via
@@ -28,7 +28,7 @@ idna==3.7
     # via requests
 imagesize==1.4.1
     # via sphinx
-ipython==8.25.0
+ipython==8.26.0
     # via dimcli
 jedi==0.19.1
     # via ipython
@@ -40,7 +40,7 @@ matplotlib-inline==0.1.7
     # via ipython
 more-itertools==10.3.0
     # via rialto-airflow (pyproject.toml)
-numpy==1.26.4
+numpy==2.0.1
     # via
     #   dimcli
     #   pandas
@@ -64,7 +64,7 @@ prompt-toolkit==3.0.47
     #   ipython
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pyalex==0.14
     # via rialto-airflow (pyproject.toml)
@@ -93,17 +93,17 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.3.7
+sphinx==7.4.7
     # via recommonmark
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
 sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.0.6
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==1.0.8
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
@@ -117,7 +117,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 tzdata==2024.1
     # via pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   pyalex
     #   requests


### PR DESCRIPTION
Seems like a good time to get Airflow and dependencies updated and see what that process might involve for the future. 

I reviewed the Airflow suggested `docker-compose.yaml` for anything new with the latest release, but nothing more was involved there than updating the Airflow version number. 

To upgrade Python dependencies:

` uv pip compile pyproject.toml -o requirements.txt --upgrade`

Tested with unit tests and also running the DAG locally. 